### PR TITLE
feat(gateway): WebSocket client with MessagePack (#3)

### DIFF
--- a/intent/errors.py
+++ b/intent/errors.py
@@ -64,3 +64,16 @@ class ServerError(HTTPException):
 
     def __init__(self, status: int, message: str) -> None:
         super().__init__(status, message, "SERVER_ERROR")
+
+
+class GatewayError(IntentError):
+    """Base exception for gateway errors."""
+
+
+class ConnectionClosed(GatewayError):
+    """WebSocket connection closed unexpectedly."""
+
+    def __init__(self, code: int | None, reason: str) -> None:
+        self.code = code
+        self.reason = reason
+        super().__init__(f"Connection closed (code={code}): {reason}")

--- a/intent/gateway.py
+++ b/intent/gateway.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
+import sys
 from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
@@ -73,8 +74,6 @@ class GatewayClient:
         while not self._closed:
             try:
                 await self._run()
-                # Clean disconnect — reset backoff so next reconnect is fast.
-                attempt = 0
             except Exception as exc:
                 if self._closed:
                     return
@@ -91,9 +90,15 @@ class GatewayClient:
     async def close(self) -> None:
         """Shut down the connection and stop reconnecting."""
         self._closed = True
-        for task in (self._heartbeat_task, self._recv_task):
-            if task and not task.done():
-                task.cancel()
+
+        # Cancel tasks and wait for them to finish before closing the socket.
+        # Without this, a concurrent send() in a task races against ws.close().
+        tasks = [t for t in (self._heartbeat_task, self._recv_task) if t and not t.done()]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
         if self._ws is not None:
             await self._ws.close()
 
@@ -117,55 +122,79 @@ class GatewayClient:
         async with connect(self._url) as ws:
             self._ws = ws
             self._heartbeat_missed = 0
+            self._seq = None  # fresh sequence for this connection
+            try:
+                await self._identify()
 
-            await self._identify()
+                # Block here until the server sends Ready (op 3).
+                ready_d = await self._wait_for_ready(ws)
+                interval_ms = int(ready_d.get("heartbeat_interval", 41250))
+                self._heartbeat_interval = interval_ms / 1000.0
+                log.info("Ready (heartbeat every %.2fs)", self._heartbeat_interval)
 
-            # Block here until the server sends Ready (op 3).
-            ready_d = await self._wait_for_ready(ws)
-            interval_ms: int = ready_d.get("heartbeat_interval", 41250)
-            self._heartbeat_interval = interval_ms / 1000.0
-            log.info("Ready (heartbeat every %.2fs)", self._heartbeat_interval)
+                # Fire READY as a pseudo-event so state can populate caches.
+                await self._dispatch("READY", ready_d, 0)
 
-            # Fire READY as a pseudo-event so state can populate caches.
-            await self._dispatch("READY", ready_d, 0)
+                # Run heartbeat and receive concurrently; stop both when either fails.
+                self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+                self._recv_task = asyncio.create_task(self._recv_loop(ws))
 
-            # Run heartbeat and receive concurrently; stop both when either fails.
-            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
-            self._recv_task = asyncio.create_task(self._recv_loop(ws))
+                done, pending = await asyncio.wait(
+                    {self._heartbeat_task, self._recv_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
 
-            done, pending = await asyncio.wait(
-                {self._heartbeat_task, self._recv_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+                for task in pending:
+                    task.cancel()
+                    try:
+                        await task
+                    except (asyncio.CancelledError, Exception):
+                        pass
 
-            for task in pending:
-                task.cancel()
-                try:
-                    await task
-                except (asyncio.CancelledError, Exception):
-                    pass
-
-            # Re-raise any exception from the task that finished first.
-            for task in done:
-                if not task.cancelled():
-                    exc = task.exception()
-                    if exc is not None:
-                        raise exc
+                # Re-raise the first exception; log any secondary one.
+                first_exc: BaseException | None = None
+                for task in done:
+                    if not task.cancelled():
+                        exc = task.exception()
+                        if exc is not None:
+                            if first_exc is None:
+                                first_exc = exc
+                            else:
+                                log.debug("Secondary task exception (suppressed): %r", exc)
+                if first_exc is not None:
+                    raise first_exc
+            finally:
+                # Clear ws ref so send() fails fast during reconnect window.
+                self._ws = None
 
     async def _wait_for_ready(self, ws: ClientConnection) -> dict[str, Any]:
         """Consume messages until Ready (op 3) arrives.
 
         Raises:
-            GatewayError: If the connection closes before Ready.
+            GatewayError: If the connection closes before Ready, or if the
+                          server sends a payload that indicates auth failure.
         """
         async for raw in ws:
             if not isinstance(raw, bytes):
                 continue
-            payload = cast(GatewayPayload, msgpack.unpackb(raw, raw=False))
-            if payload.get("op", -1) == OP_READY:
+
+            raw_payload = msgpack.unpackb(raw, raw=False)
+            if not isinstance(raw_payload, dict):
+                log.warning("Non-dict msgpack frame before Ready (type=%s), ignoring",
+                            type(raw_payload).__name__)
+                continue
+
+            payload = cast(GatewayPayload, raw_payload)
+            op = payload.get("op", -1)
+
+            if op == OP_READY:
                 d = payload.get("d")
                 return d if isinstance(d, dict) else {}
-            log.debug("Ignoring op %d before Ready", payload.get("op", -1))
+
+            # Any other opcode before Ready is unexpected — log at warning so
+            # auth failures (e.g. future op 8 Invalid Session) surface clearly.
+            log.warning("Unexpected op %d before Ready, ignoring", op)
+
         raise GatewayError("Connection closed before Ready received")
 
     async def _identify(self) -> None:
@@ -174,7 +203,7 @@ class GatewayClient:
             OP_IDENTIFY,
             {
                 "token": self.token,
-                "properties": {"os": "linux", "browser": "intent.py", "device": "bot"},
+                "properties": {"os": sys.platform, "browser": "intent.py", "device": "bot"},
             },
         )
         log.debug("Sent Identify")
@@ -184,6 +213,8 @@ class GatewayClient:
 
         Tracks missed ACKs; 3 consecutive missed ACKs = dead connection.
         Counter increments on send, resets to 0 when an ACK arrives.
+        Raises ConnectionClosed rather than closing the socket directly —
+        the _run() context manager handles the actual WS close on exit.
         """
         while True:
             await asyncio.sleep(self._heartbeat_interval)
@@ -193,9 +224,7 @@ class GatewayClient:
             log.debug("Heartbeat sent (outstanding=%d)", self._heartbeat_missed)
 
             if self._heartbeat_missed >= 3:
-                log.warning("3 missed heartbeat ACKs — closing connection")
-                if self._ws is not None:
-                    await self._ws.close()
+                log.warning("3 missed heartbeat ACKs — dropping connection")
                 raise ConnectionClosed(None, "Heartbeat timeout")
 
     async def _recv_loop(self, ws: ClientConnection) -> None:
@@ -204,7 +233,14 @@ class GatewayClient:
             if not isinstance(raw, bytes):
                 log.debug("Non-binary frame received, ignoring")
                 continue
-            payload = cast(GatewayPayload, msgpack.unpackb(raw, raw=False))
+
+            raw_payload = msgpack.unpackb(raw, raw=False)
+            if not isinstance(raw_payload, dict):
+                log.warning("Non-dict msgpack frame (type=%s), ignoring",
+                            type(raw_payload).__name__)
+                continue
+
+            payload = cast(GatewayPayload, raw_payload)
             await self._handle(payload)
 
     async def _handle(self, payload: GatewayPayload) -> None:
@@ -218,7 +254,10 @@ class GatewayClient:
                 return
             seq: int = payload.get("s") or 0
             self._seq = seq
-            await self._dispatch(event, payload.get("d"), seq)
+            try:
+                await self._dispatch(event, payload.get("d"), seq)
+            except Exception:
+                log.exception("Unhandled exception in dispatch callback for %s", event)
 
         elif op == OP_HEARTBEAT_ACK:
             self._heartbeat_missed = 0

--- a/intent/gateway.py
+++ b/intent/gateway.py
@@ -1,3 +1,238 @@
-"""WebSocket gateway with MessagePack protocol."""
+"""WebSocket gateway client with MessagePack protocol."""
 
-# Placeholder - will be implemented in issue #3
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+from typing import Any, cast
+
+import msgpack  # type: ignore[import-untyped]
+from websockets.asyncio.client import ClientConnection, connect
+
+from .errors import ConnectionClosed, GatewayError
+from .types.gateway import GatewayPayload
+
+__all__ = ("GatewayClient",)
+
+log = logging.getLogger(__name__)
+
+# Reconnect backoff steps in seconds; capped at the last value
+_BACKOFF_STEPS = [1.0, 2.0, 4.0, 8.0, 16.0, 30.0]
+_JITTER = 0.25  # ±25% of base delay
+
+# Opcodes used in Phase 1
+OP_DISPATCH = 0
+OP_HEARTBEAT = 1
+OP_IDENTIFY = 2
+OP_READY = 3
+OP_HEARTBEAT_ACK = 11
+
+
+class GatewayClient:
+    """WebSocket client for the Intent gateway.
+
+    Handles the full connection lifecycle: identify, ready, heartbeat, and event
+    dispatch. Reconnects automatically on failure using exponential backoff.
+
+    Args:
+        token: Bot or user token for Identify.
+        dispatch: Async callback invoked for every Dispatch event:
+                  ``await dispatch(event_name, data, seq)``.
+        url: Gateway WebSocket URL.
+    """
+
+    def __init__(
+        self,
+        token: str,
+        dispatch: Callable[[str, Any, int], Awaitable[None]],
+        *,
+        url: str = "wss://gateway.intent.chat/",
+    ) -> None:
+        self.token = token
+        self._dispatch = dispatch
+        self._url = url
+
+        self._ws: ClientConnection | None = None
+        self._closed = False
+        self._heartbeat_interval = 41.25  # overwritten by Ready payload
+        self._heartbeat_missed = 0
+        self._seq: int | None = None  # last received sequence number
+
+        self._heartbeat_task: asyncio.Task[None] | None = None
+        self._recv_task: asyncio.Task[None] | None = None
+
+    async def connect(self) -> None:
+        """Connect to the gateway and reconnect on failure.
+
+        Runs until ``close()`` is called. Reconnection uses exponential backoff
+        with jitter to avoid thundering herd on server restarts.
+        """
+        attempt = 0
+        while not self._closed:
+            try:
+                await self._run()
+                # Clean disconnect — reset backoff so next reconnect is fast.
+                attempt = 0
+            except Exception as exc:
+                if self._closed:
+                    return
+                log.warning("Gateway disconnected: %r", exc)
+
+            if self._closed:
+                return
+
+            delay = self._backoff_delay(attempt)
+            log.info("Reconnecting in %.2fs (attempt %d)", delay, attempt + 1)
+            await asyncio.sleep(delay)
+            attempt += 1
+
+    async def close(self) -> None:
+        """Shut down the connection and stop reconnecting."""
+        self._closed = True
+        for task in (self._heartbeat_task, self._recv_task):
+            if task and not task.done():
+                task.cancel()
+        if self._ws is not None:
+            await self._ws.close()
+
+    async def send(self, op: int, d: Any = None) -> None:
+        """Pack and transmit a gateway payload.
+
+        Raises:
+            GatewayError: If called when not connected.
+        """
+        if self._ws is None:
+            raise GatewayError("Not connected")
+        payload: dict[str, Any] = {"op": op, "d": d}
+        await self._ws.send(msgpack.packb(payload, use_bin_type=True))
+
+    # ------------------------------------------------------------------
+    # Internal connection lifecycle
+    # ------------------------------------------------------------------
+
+    async def _run(self) -> None:
+        """Run one connection attempt from open to close."""
+        async with connect(self._url) as ws:
+            self._ws = ws
+            self._heartbeat_missed = 0
+
+            await self._identify()
+
+            # Block here until the server sends Ready (op 3).
+            ready_d = await self._wait_for_ready(ws)
+            interval_ms: int = ready_d.get("heartbeat_interval", 41250)
+            self._heartbeat_interval = interval_ms / 1000.0
+            log.info("Ready (heartbeat every %.2fs)", self._heartbeat_interval)
+
+            # Fire READY as a pseudo-event so state can populate caches.
+            await self._dispatch("READY", ready_d, 0)
+
+            # Run heartbeat and receive concurrently; stop both when either fails.
+            self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+            self._recv_task = asyncio.create_task(self._recv_loop(ws))
+
+            done, pending = await asyncio.wait(
+                {self._heartbeat_task, self._recv_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+
+            for task in pending:
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+
+            # Re-raise any exception from the task that finished first.
+            for task in done:
+                if not task.cancelled():
+                    exc = task.exception()
+                    if exc is not None:
+                        raise exc
+
+    async def _wait_for_ready(self, ws: ClientConnection) -> dict[str, Any]:
+        """Consume messages until Ready (op 3) arrives.
+
+        Raises:
+            GatewayError: If the connection closes before Ready.
+        """
+        async for raw in ws:
+            if not isinstance(raw, bytes):
+                continue
+            payload = cast(GatewayPayload, msgpack.unpackb(raw, raw=False))
+            if payload.get("op", -1) == OP_READY:
+                d = payload.get("d")
+                return d if isinstance(d, dict) else {}
+            log.debug("Ignoring op %d before Ready", payload.get("op", -1))
+        raise GatewayError("Connection closed before Ready received")
+
+    async def _identify(self) -> None:
+        """Send the Identify payload (op 2)."""
+        await self.send(
+            OP_IDENTIFY,
+            {
+                "token": self.token,
+                "properties": {"os": "linux", "browser": "intent.py", "device": "bot"},
+            },
+        )
+        log.debug("Sent Identify")
+
+    async def _heartbeat_loop(self) -> None:
+        """Send heartbeats on the server-specified interval.
+
+        Tracks missed ACKs; 3 consecutive missed ACKs = dead connection.
+        Counter increments on send, resets to 0 when an ACK arrives.
+        """
+        while True:
+            await asyncio.sleep(self._heartbeat_interval)
+
+            await self.send(OP_HEARTBEAT, self._seq)
+            self._heartbeat_missed += 1
+            log.debug("Heartbeat sent (outstanding=%d)", self._heartbeat_missed)
+
+            if self._heartbeat_missed >= 3:
+                log.warning("3 missed heartbeat ACKs — closing connection")
+                if self._ws is not None:
+                    await self._ws.close()
+                raise ConnectionClosed(None, "Heartbeat timeout")
+
+    async def _recv_loop(self, ws: ClientConnection) -> None:
+        """Receive and handle all incoming gateway frames."""
+        async for raw in ws:
+            if not isinstance(raw, bytes):
+                log.debug("Non-binary frame received, ignoring")
+                continue
+            payload = cast(GatewayPayload, msgpack.unpackb(raw, raw=False))
+            await self._handle(payload)
+
+    async def _handle(self, payload: GatewayPayload) -> None:
+        """Route an incoming payload by opcode."""
+        op = payload.get("op", -1)
+
+        if op == OP_DISPATCH:
+            event: str | None = payload.get("t")
+            if not event:
+                log.warning("Received Dispatch with missing event name, skipping")
+                return
+            seq: int = payload.get("s") or 0
+            self._seq = seq
+            await self._dispatch(event, payload.get("d"), seq)
+
+        elif op == OP_HEARTBEAT_ACK:
+            self._heartbeat_missed = 0
+            log.debug("Heartbeat ACK")
+
+        elif op == OP_HEARTBEAT:
+            # Server requesting an immediate heartbeat (rare but valid).
+            await self.send(OP_HEARTBEAT, self._seq)
+
+        else:
+            log.debug("Unhandled opcode %d", op)
+
+    def _backoff_delay(self, attempt: int) -> float:
+        """Return a jittered backoff delay for the given attempt number."""
+        base = _BACKOFF_STEPS[min(attempt, len(_BACKOFF_STEPS) - 1)]
+        jitter = base * _JITTER
+        return base + random.uniform(-jitter, jitter)

--- a/intent/types/gateway.py
+++ b/intent/types/gateway.py
@@ -15,10 +15,15 @@ class GatewayPayload(TypedDict, total=False):
     s: int  # Sequence number (Dispatch only)
 
 
-class IdentifyPayload(TypedDict, total=False):
-    """Identify payload (op 2)."""
+class _IdentifyRequired(TypedDict):
+    """Required fields for Identify payload."""
 
     token: str
+
+
+class IdentifyPayload(_IdentifyRequired, total=False):
+    """Identify payload (op 2). token is required; intents and properties are optional."""
+
     intents: int
     properties: dict[str, str]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "aiohttp>=3.9.0",
     "msgpack>=1.0.0",
+    "websockets>=13.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -197,6 +197,19 @@ class TestHandle:
 
         assert received == []
 
+    async def test_dispatch_exception_is_caught_not_propagated(self) -> None:
+        # An exception inside the dispatch callback must not crash the recv loop.
+        async def bad_dispatch(event: str, data: Any, seq: int) -> None:
+            raise RuntimeError("callback blew up")
+
+        client = GatewayClient("t", bad_dispatch)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        # Should not raise — exception is caught and logged.
+        payload = {"op": OP_DISPATCH, "t": "MESSAGE_CREATE", "s": 1, "d": {}}
+        await client._handle(payload)  # type: ignore[arg-type]
+
 
 # ---------------------------------------------------------------------------
 # _wait_for_ready()
@@ -247,6 +260,20 @@ class TestWaitForReady:
         result = await client._wait_for_ready(ws)  # type: ignore[arg-type]
         assert result["heartbeat_interval"] == 1000
 
+    async def test_ignores_non_dict_msgpack_frame(self) -> None:
+        # A valid msgpack frame that is not a dict (e.g., a bare int) must be skipped.
+        import msgpack as mp
+
+        client = GatewayClient("t", noop)
+        ws = MockWS([
+            mp.packb(42, use_bin_type=True),  # bare int — invalid gateway frame
+            pack(OP_READY, {"heartbeat_interval": 2000, "user": {}, "servers": []}),
+        ])
+        client._ws = ws  # type: ignore[assignment]
+
+        result = await client._wait_for_ready(ws)  # type: ignore[arg-type]
+        assert result["heartbeat_interval"] == 2000
+
 
 # ---------------------------------------------------------------------------
 # _identify()
@@ -279,15 +306,16 @@ class TestHeartbeatLoop:
         client = GatewayClient("t", noop)
         ws = MockWS([])
         client._ws = ws  # type: ignore[assignment]
-        # Counter starts at 2; on the next iteration it sends, increments to 3, then closes.
+        # Counter starts at 2; on the next iteration it sends, increments to 3, then raises.
         client._heartbeat_missed = 2
 
         with patch("asyncio.sleep", new_callable=AsyncMock):
             with pytest.raises(ConnectionClosed, match="Heartbeat timeout"):
                 await client._heartbeat_loop()
 
-        ws.close.assert_called_once()
-        # One heartbeat was sent before the close.
+        # heartbeat_loop no longer closes ws directly — _run() context manager does that.
+        ws.close.assert_not_called()
+        # One heartbeat was sent before raising.
         assert ws.send.call_count == 1
 
     async def test_increments_missed_and_sends_heartbeat(self) -> None:
@@ -343,9 +371,9 @@ class TestClose:
         client._heartbeat_task = asyncio.create_task(long_running())
         client._recv_task = asyncio.create_task(long_running())
 
+        # close() now awaits the cancelled tasks internally via gather, so they
+        # are fully cancelled before close() returns.
         await client.close()
-        # Let the event loop process the CancelledError in each task.
-        await asyncio.sleep(0)
 
         assert client._heartbeat_task.cancelled()
         assert client._recv_task.cancelled()
@@ -356,3 +384,48 @@ class TestClose:
         client._ws = ws  # type: ignore[assignment]
         # No tasks set — should not raise
         await client.close()
+
+
+# ---------------------------------------------------------------------------
+# _recv_loop()
+# ---------------------------------------------------------------------------
+
+
+class TestRecvLoop:
+    async def test_non_dict_msgpack_frame_skipped(self) -> None:
+        import msgpack as mp
+
+        received: list[str] = []
+
+        async def capture(event: str, data: Any, seq: int) -> None:
+            received.append(event)
+
+        client = GatewayClient("t", capture)
+        # bare int frame followed by a valid dispatch
+        ws = MockWS([
+            mp.packb(99, use_bin_type=True),
+            pack(OP_DISPATCH, {"content": "hi"}, t="MESSAGE_CREATE", s=1),
+        ])
+        client._ws = ws  # type: ignore[assignment]
+
+        await client._recv_loop(ws)  # type: ignore[arg-type]
+
+        # Only the valid dispatch should have reached the callback.
+        assert received == ["MESSAGE_CREATE"]
+
+    async def test_non_binary_frame_skipped(self) -> None:
+        received: list[str] = []
+
+        async def capture(event: str, data: Any, seq: int) -> None:
+            received.append(event)
+
+        client = GatewayClient("t", capture)
+        ws = MockWS([
+            "stray text frame",
+            pack(OP_DISPATCH, {"content": "hi"}, t="SERVER_CREATE", s=2),
+        ])
+        client._ws = ws  # type: ignore[assignment]
+
+        await client._recv_loop(ws)  # type: ignore[arg-type]
+
+        assert received == ["SERVER_CREATE"]

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -1,0 +1,358 @@
+"""Tests for gateway client."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import msgpack
+import pytest
+
+from intent.errors import ConnectionClosed, GatewayError
+from intent.gateway import (
+    OP_DISPATCH,
+    OP_HEARTBEAT,
+    OP_HEARTBEAT_ACK,
+    OP_IDENTIFY,
+    OP_READY,
+    GatewayClient,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def pack(op: int, d: Any = None, t: str | None = None, s: int | None = None) -> bytes:
+    """Build a msgpack-encoded gateway payload."""
+    payload: dict[str, Any] = {"op": op, "d": d}
+    if t is not None:
+        payload["t"] = t
+    if s is not None:
+        payload["s"] = s
+    return msgpack.packb(payload, use_bin_type=True)
+
+
+async def noop(event: str, data: Any, seq: int) -> None:
+    """No-op dispatch callback."""
+
+
+class MockWS:
+    """Minimal WebSocket stand-in for testing. Supports async iteration and send/close.
+
+    Accepts both bytes and str in the message list to let tests cover the
+    non-binary frame guard.
+    """
+
+    def __init__(self, messages: list[bytes | str]) -> None:
+        self._messages = messages
+        self._index = 0
+        self.send = AsyncMock()
+        self.close = AsyncMock()
+
+    def __aiter__(self) -> MockWS:
+        return self
+
+    async def __anext__(self) -> bytes | str:
+        if self._index >= len(self._messages):
+            raise StopAsyncIteration
+        msg = self._messages[self._index]
+        self._index += 1
+        return msg
+
+    async def __aenter__(self) -> MockWS:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Backoff
+# ---------------------------------------------------------------------------
+
+
+class TestBackoff:
+    def test_first_attempt_range(self) -> None:
+        client = GatewayClient("t", noop)
+        delay = client._backoff_delay(0)
+        # base=1.0s, jitter ±25% → [0.75, 1.25]
+        assert 0.75 <= delay <= 1.25
+
+    def test_scales_with_attempt(self) -> None:
+        client = GatewayClient("t", noop)
+        d0 = client._backoff_delay(0)
+        d3 = client._backoff_delay(3)
+        # attempt 3 has base 8.0 vs base 1.0, so d3 should generally be larger
+        assert d3 > d0
+
+    def test_capped_at_max_step(self) -> None:
+        client = GatewayClient("t", noop)
+        # Both should use the 30s max step (±25% → [22.5, 37.5])
+        for attempt in (5, 50, 999):
+            delay = client._backoff_delay(attempt)
+            assert 22.5 <= delay <= 37.5
+
+
+# ---------------------------------------------------------------------------
+# send()
+# ---------------------------------------------------------------------------
+
+
+class TestSend:
+    async def test_raises_when_not_connected(self) -> None:
+        client = GatewayClient("t", noop)
+        with pytest.raises(GatewayError, match="Not connected"):
+            await client.send(OP_HEARTBEAT)
+
+    async def test_encodes_op_and_data(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        await client.send(OP_HEARTBEAT, 42)
+
+        expected = msgpack.packb({"op": OP_HEARTBEAT, "d": 42}, use_bin_type=True)
+        ws.send.assert_called_once_with(expected)
+
+    async def test_none_data_serialized(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        await client.send(OP_HEARTBEAT)
+
+        expected = msgpack.packb({"op": OP_HEARTBEAT, "d": None}, use_bin_type=True)
+        ws.send.assert_called_once_with(expected)
+
+
+# ---------------------------------------------------------------------------
+# _handle()
+# ---------------------------------------------------------------------------
+
+
+class TestHandle:
+    async def test_dispatch_invokes_callback(self) -> None:
+        received: list[tuple[str, Any, int]] = []
+
+        async def capture(event: str, data: Any, seq: int) -> None:
+            received.append((event, data, seq))
+
+        client = GatewayClient("t", capture)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        payload = {"op": OP_DISPATCH, "t": "MESSAGE_CREATE", "s": 7, "d": {"content": "hi"}}
+        await client._handle(payload)  # type: ignore[arg-type]
+
+        assert received == [("MESSAGE_CREATE", {"content": "hi"}, 7)]
+
+    async def test_dispatch_tracks_sequence(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        await client._handle({"op": OP_DISPATCH, "t": "X", "s": 15, "d": None})  # type: ignore[arg-type]
+
+        assert client._seq == 15
+
+    async def test_heartbeat_ack_resets_missed_counter(self) -> None:
+        client = GatewayClient("t", noop)
+        client._heartbeat_missed = 3
+
+        await client._handle({"op": OP_HEARTBEAT_ACK, "d": None})  # type: ignore[arg-type]
+
+        assert client._heartbeat_missed == 0
+
+    async def test_server_heartbeat_echoes_seq(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+        client._seq = 9
+
+        await client._handle({"op": OP_HEARTBEAT, "d": None})  # type: ignore[arg-type]
+
+        expected = msgpack.packb({"op": OP_HEARTBEAT, "d": 9}, use_bin_type=True)
+        ws.send.assert_called_once_with(expected)
+
+    async def test_unknown_opcode_is_ignored(self) -> None:
+        # Should not raise — just log at debug
+        client = GatewayClient("t", noop)
+        await client._handle({"op": 99, "d": None})  # type: ignore[arg-type]
+
+    async def test_dispatch_missing_event_name_skipped(self) -> None:
+        # Malformed Dispatch with no "t" field must not invoke the callback.
+        received: list[Any] = []
+
+        async def capture(event: str, data: Any, seq: int) -> None:
+            received.append(event)
+
+        client = GatewayClient("t", capture)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        # Dispatch payload with no "t" key
+        await client._handle({"op": OP_DISPATCH, "s": 1, "d": {}})  # type: ignore[arg-type]
+
+        assert received == []
+
+
+# ---------------------------------------------------------------------------
+# _wait_for_ready()
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForReady:
+    async def test_returns_ready_payload(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([
+            pack(OP_READY, {"heartbeat_interval": 30000, "user": {}, "servers": []}),
+        ])
+        client._ws = ws  # type: ignore[assignment]
+
+        result = await client._wait_for_ready(ws)  # type: ignore[arg-type]
+
+        assert result["heartbeat_interval"] == 30000
+
+    async def test_skips_messages_before_ready(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([
+            pack(OP_DISPATCH, {"foo": 1}, t="OTHER", s=1),
+            pack(OP_READY, {"heartbeat_interval": 5000, "user": {}, "servers": []}),
+        ])
+        client._ws = ws  # type: ignore[assignment]
+
+        result = await client._wait_for_ready(ws)  # type: ignore[arg-type]
+
+        assert result["heartbeat_interval"] == 5000
+
+    async def test_raises_on_connection_close_before_ready(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])  # empty = closed before Ready
+        client._ws = ws  # type: ignore[assignment]
+
+        with pytest.raises(GatewayError, match="Connection closed before Ready"):
+            await client._wait_for_ready(ws)  # type: ignore[arg-type]
+
+    async def test_ignores_non_binary_frames(self) -> None:
+        # A stray text frame before Ready should be skipped; Ready still returned.
+        client = GatewayClient("t", noop)
+        ws = MockWS([
+            "this is a text frame and should be ignored",
+            pack(OP_READY, {"heartbeat_interval": 1000, "user": {}, "servers": []}),
+        ])
+        client._ws = ws  # type: ignore[assignment]
+
+        result = await client._wait_for_ready(ws)  # type: ignore[arg-type]
+        assert result["heartbeat_interval"] == 1000
+
+
+# ---------------------------------------------------------------------------
+# _identify()
+# ---------------------------------------------------------------------------
+
+
+class TestIdentify:
+    async def test_sends_identify_opcode(self) -> None:
+        client = GatewayClient("secret_token", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        await client._identify()
+
+        ws.send.assert_called_once()
+        sent_bytes: bytes = ws.send.call_args[0][0]
+        decoded = msgpack.unpackb(sent_bytes, raw=False)
+        assert decoded["op"] == OP_IDENTIFY
+        assert decoded["d"]["token"] == "secret_token"
+        assert "properties" in decoded["d"]
+
+
+# ---------------------------------------------------------------------------
+# _heartbeat_loop()
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeatLoop:
+    async def test_raises_after_three_missed_acks(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+        # Counter starts at 2; on the next iteration it sends, increments to 3, then closes.
+        client._heartbeat_missed = 2
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            with pytest.raises(ConnectionClosed, match="Heartbeat timeout"):
+                await client._heartbeat_loop()
+
+        ws.close.assert_called_once()
+        # One heartbeat was sent before the close.
+        assert ws.send.call_count == 1
+
+    async def test_increments_missed_and_sends_heartbeat(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+        client._heartbeat_missed = 0
+        client._seq = 10
+
+        call_count = 0
+
+        async def fake_sleep(delay: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError
+
+        with patch("asyncio.sleep", side_effect=fake_sleep):
+            with pytest.raises(asyncio.CancelledError):
+                await client._heartbeat_loop()
+
+        # One heartbeat should have been sent
+        assert ws.send.call_count == 1
+        expected = msgpack.packb({"op": OP_HEARTBEAT, "d": 10}, use_bin_type=True)
+        ws.send.assert_called_with(expected)
+        assert client._heartbeat_missed == 1
+
+
+# ---------------------------------------------------------------------------
+# close()
+# ---------------------------------------------------------------------------
+
+
+class TestClose:
+    async def test_sets_closed_flag(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        await client.close()
+
+        assert client._closed
+        ws.close.assert_called_once()
+
+    async def test_cancels_pending_tasks(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+
+        async def long_running() -> None:
+            await asyncio.sleep(9999)
+
+        client._heartbeat_task = asyncio.create_task(long_running())
+        client._recv_task = asyncio.create_task(long_running())
+
+        await client.close()
+        # Let the event loop process the CancelledError in each task.
+        await asyncio.sleep(0)
+
+        assert client._heartbeat_task.cancelled()
+        assert client._recv_task.cancelled()
+
+    async def test_no_error_when_no_tasks(self) -> None:
+        client = GatewayClient("t", noop)
+        ws = MockWS([])
+        client._ws = ws  # type: ignore[assignment]
+        # No tasks set — should not raise
+        await client.close()

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,6 +1,5 @@
 """Tests for HTTP client."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest


### PR DESCRIPTION
Implements the gateway WebSocket client against the current protocol spec.

Connect → Identify → Ready → heartbeat loop. Binary MessagePack throughout, no JSON. Reconnects automatically with exponential backoff and jitter. Three consecutive missed heartbeat ACKs closes the connection.

Dispatch callback is a plain async callable so the client layer (issue #5) can wire it up without gateway knowing about state internals.

Also adds `GatewayError` and `ConnectionClosed` to the error hierarchy, and pulls in `websockets>=13.0`.