### PR TITLE
feat(state): ConnectionState cache with dispatch parsing

### DIFF
--- a/intent/state.py
+++ b/intent/state.py
@@ -2,20 +2,123 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Any, cast
+
+from .models.channel import Channel
+from .models.message import Message
+from .models.server import Server
+from .models.user import User
+from .types.channel import ChannelPayload
+from .types.message import MessagePayload
+from .types.server import ServerPayload
 
 if TYPE_CHECKING:
     from .http import HTTPClient
+    from .types.gateway import ReadyPayload
+
+log = logging.getLogger(__name__)
+
+_ParseResult = tuple[str, list[Any]]
 
 
 class ConnectionState:
-    """
-    Central state manager for the client.
+    """Central state manager bridging raw gateway events and the model layer.
 
-    Placeholder - will be fully implemented in issue #5.
+    Parses dispatch payloads into model objects, maintains ID-keyed caches,
+    and returns (event_name, args) tuples for the Client to fire to listeners.
+
+    Parser methods are auto-discovered via ``parse_{event_name_lower}`` so
+    adding a new event is just a new method — no routing table to update.
     """
 
-    http: HTTPClient
+    __slots__ = ("http", "_user", "_users", "_servers", "_channels")
 
     def __init__(self, http: HTTPClient) -> None:
         self.http = http
+        self._user: User | None = None
+        self._users: dict[str, User] = {}
+        self._servers: dict[str, Server] = {}
+        self._channels: dict[str, Channel] = {}
+
+    # -- public accessors --
+
+    @property
+    def user(self) -> User | None:
+        return self._user
+
+    @property
+    def servers(self) -> list[Server]:
+        return list(self._servers.values())
+
+    def get_user(self, user_id: str) -> User | None:
+        return self._users.get(user_id)
+
+    def get_server(self, server_id: str) -> Server | None:
+        return self._servers.get(server_id)
+
+    def get_channel(self, channel_id: str) -> Channel | None:
+        return self._channels.get(channel_id)
+
+    # -- dispatch router --
+
+    def parse_dispatch(self, event: str, data: dict[str, Any]) -> _ParseResult | None:
+        """Route a raw gateway dispatch to the matching parse_* method.
+
+        Returns (event_name, args) for the Client to emit, or None if
+        the event type has no parser (not an error — just unhandled).
+        """
+        method_name = f"parse_{event.lower()}"
+        handler: Any = getattr(self, method_name, None)
+        if handler is not None:
+            result: _ParseResult = handler(data)
+            return result
+        log.debug("No parser for dispatch event %s", event)
+        return None
+
+    # -- individual parsers --
+
+    def parse_ready(self, data: ReadyPayload) -> _ParseResult:
+        # Fresh session — wipe stale state from any previous connection
+        self.clear()
+
+        self._user = User(data=data["user"], state=self)
+        self._users[self._user.id] = self._user
+
+        for raw_server in data["servers"]:
+            server = Server(data=raw_server, state=self)
+            self._servers[server.id] = server
+
+        return ("ready", [self._user, self.servers])
+
+    def parse_message_create(self, data: dict[str, Any]) -> _ParseResult:
+        msg = Message(data=cast(MessagePayload, data), state=self)
+        self._users[msg.author.id] = msg.author
+        return ("message_create", [msg])
+
+    def parse_message_update(self, data: dict[str, Any]) -> _ParseResult:
+        msg = Message(data=cast(MessagePayload, data), state=self)
+        self._users[msg.author.id] = msg.author
+        return ("message_update", [msg])
+
+    def parse_message_delete(self, data: dict[str, Any]) -> _ParseResult:
+        return ("message_delete", [data["id"], data["channel_id"]])
+
+    def parse_server_create(self, data: dict[str, Any]) -> _ParseResult:
+        server = Server(data=cast(ServerPayload, data), state=self)
+        self._servers[server.id] = server
+        return ("server_create", [server])
+
+    def parse_channel_create(self, data: dict[str, Any]) -> _ParseResult:
+        channel = Channel(data=cast(ChannelPayload, data), state=self)
+        self._channels[channel.id] = channel
+        return ("channel_create", [channel])
+
+    # -- cache management --
+
+    def clear(self) -> None:
+        """Wipe all caches. Called on full reconnect (non-resume)."""
+        self._user = None
+        self._users.clear()
+        self._servers.clear()
+        self._channels.clear()

--- a/intent/state.py
+++ b/intent/state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import ValuesView
 from typing import TYPE_CHECKING, Any, cast
 
 from .models.channel import Channel
@@ -48,8 +49,8 @@ class ConnectionState:
         return self._user
 
     @property
-    def servers(self) -> list[Server]:
-        return list(self._servers.values())
+    def servers(self) -> ValuesView[Server]:
+        return self._servers.values()
 
     def get_user(self, user_id: str) -> User | None:
         return self._users.get(user_id)

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,227 @@
+"""Tests for ConnectionState dispatch parsing and caching."""
+
+from intent.http import HTTPClient
+from intent.models import Channel, Message, Server
+from intent.state import ConnectionState
+
+
+def _make_state() -> ConnectionState:
+    return ConnectionState(HTTPClient(token="test"))
+
+
+def _user_payload(
+    id: str = "100", username: str = "alice", display_name: str = "Alice"
+) -> dict:
+    return {
+        "id": id,
+        "username": username,
+        "display_name": display_name,
+        "avatar_url": None,
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+
+
+def _server_payload(id: str = "1", name: str = "Test Server") -> dict:
+    return {
+        "id": id,
+        "name": name,
+        "owner_id": "100",
+        "icon_url": None,
+        "description": None,
+        "member_count": 10,
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+
+
+def _channel_payload(id: str = "200", server_id: str = "1") -> dict:
+    return {
+        "id": id,
+        "server_id": server_id,
+        "name": "general",
+        "type": 0,
+        "topic": None,
+        "position": 0,
+        "parent_id": None,
+        "created_at": "2025-01-01T00:00:00Z",
+    }
+
+
+def _message_payload(id: str = "300", channel_id: str = "200") -> dict:
+    return {
+        "id": id,
+        "channel_id": channel_id,
+        "author": _user_payload(),
+        "content": "hello world",
+        "created_at": "2025-01-01T00:00:00Z",
+        "edited_at": None,
+        "webhook_id": None,
+    }
+
+
+class TestParseDispatch:
+    """Routing raw events to the right parser."""
+
+    def test_routes_to_parser(self) -> None:
+        state = _make_state()
+        result = state.parse_dispatch("MESSAGE_CREATE", _message_payload())
+        assert result is not None
+        assert result[0] == "message_create"
+
+    def test_returns_none_for_unknown_event(self) -> None:
+        state = _make_state()
+        result = state.parse_dispatch("UNKNOWN_EVENT", {})
+        assert result is None
+
+
+class TestParseReady:
+    """READY event populates self user and server cache."""
+
+    def test_sets_user_and_servers(self) -> None:
+        state = _make_state()
+        ready = {
+            "user": _user_payload(),
+            "servers": [_server_payload("1"), _server_payload("2", "Second")],
+            "heartbeat_interval": 30000,
+        }
+        result = state.parse_dispatch("READY", ready)
+
+        assert result is not None
+        event, args = result
+        assert event == "ready"
+
+        assert state.user is not None
+        assert state.user.id == "100"
+        assert state.user.username == "alice"
+
+        assert len(state.servers) == 2
+        assert state.get_server("1") is not None
+        assert state.get_server("2") is not None
+
+    def test_caches_self_user(self) -> None:
+        state = _make_state()
+        ready = {
+            "user": _user_payload(),
+            "servers": [],
+            "heartbeat_interval": 30000,
+        }
+        state.parse_dispatch("READY", ready)
+        assert state.get_user("100") is not None
+
+
+class TestParseMessageCreate:
+    """MESSAGE_CREATE builds a Message and caches the author."""
+
+    def test_returns_message(self) -> None:
+        state = _make_state()
+        result = state.parse_dispatch("MESSAGE_CREATE", _message_payload())
+
+        assert result is not None
+        event, args = result
+        assert event == "message_create"
+        msg = args[0]
+        assert isinstance(msg, Message)
+        assert msg.id == "300"
+        assert msg.content == "hello world"
+
+    def test_caches_author(self) -> None:
+        state = _make_state()
+        state.parse_dispatch("MESSAGE_CREATE", _message_payload())
+        assert state.get_user("100") is not None
+        assert state.get_user("100").username == "alice"  # type: ignore[union-attr]
+
+
+class TestParseMessageUpdate:
+    """MESSAGE_UPDATE builds a fresh Message and updates the author cache."""
+
+    def test_returns_updated_message(self) -> None:
+        state = _make_state()
+        payload = _message_payload()
+        payload["content"] = "edited content"
+        result = state.parse_dispatch("MESSAGE_UPDATE", payload)
+
+        assert result is not None
+        msg = result[1][0]
+        assert isinstance(msg, Message)
+        assert msg.content == "edited content"
+
+
+class TestParseMessageDelete:
+    """MESSAGE_DELETE returns raw id and channel_id."""
+
+    def test_returns_ids(self) -> None:
+        state = _make_state()
+        result = state.parse_dispatch(
+            "MESSAGE_DELETE", {"id": "300", "channel_id": "200"}
+        )
+
+        assert result is not None
+        event, args = result
+        assert event == "message_delete"
+        assert args == ["300", "200"]
+
+
+class TestParseServerCreate:
+    """SERVER_CREATE builds a Server and caches it."""
+
+    def test_creates_and_caches(self) -> None:
+        state = _make_state()
+        result = state.parse_dispatch("SERVER_CREATE", _server_payload("5", "New"))
+
+        assert result is not None
+        event, args = result
+        assert event == "server_create"
+        srv = args[0]
+        assert isinstance(srv, Server)
+        assert srv.name == "New"
+        assert state.get_server("5") is srv
+
+
+class TestParseChannelCreate:
+    """CHANNEL_CREATE builds a Channel and caches it."""
+
+    def test_creates_and_caches(self) -> None:
+        state = _make_state()
+        result = state.parse_dispatch("CHANNEL_CREATE", _channel_payload("55"))
+
+        assert result is not None
+        event, args = result
+        assert event == "channel_create"
+        ch = args[0]
+        assert isinstance(ch, Channel)
+        assert ch.id == "55"
+        assert state.get_channel("55") is ch
+
+
+class TestCacheLookups:
+    """Cache accessor methods."""
+
+    def test_get_nonexistent_returns_none(self) -> None:
+        state = _make_state()
+        assert state.get_user("nope") is None
+        assert state.get_server("nope") is None
+        assert state.get_channel("nope") is None
+
+
+class TestClear:
+    """clear() wipes all state."""
+
+    def test_clears_everything(self) -> None:
+        state = _make_state()
+        ready = {
+            "user": _user_payload(),
+            "servers": [_server_payload()],
+            "heartbeat_interval": 30000,
+        }
+        state.parse_dispatch("READY", ready)
+        state.parse_dispatch("CHANNEL_CREATE", _channel_payload())
+        state.parse_dispatch("MESSAGE_CREATE", _message_payload())
+
+        assert state.user is not None
+        assert len(state.servers) == 1
+
+        state.clear()
+
+        assert state.user is None
+        assert len(state.servers) == 0
+        assert state.get_user("100") is None
+        assert state.get_channel("200") is None


### PR DESCRIPTION
## Summary
- ConnectionState parses raw gateway dicts into model objects and maintains ID-keyed caches for users, servers, and channels
- Dispatch routing via auto-discovered `parse_*` methods — no routing table, just add a method for a new event
- All five Phase 1 events handled: MESSAGE_CREATE, MESSAGE_UPDATE, MESSAGE_DELETE, SERVER_CREATE, CHANNEL_CREATE
- parse_ready clears stale state before repopulating so reconnects don't leak old data
- 12 new tests in test_state.py, mypy strict and ruff clean

Closes #7

## Test plan
- [x] `pytest tests/ -v` — 59 passed (47 existing + 12 new)
- [x] `mypy intent/ --strict` — clean
- [x] `ruff check intent/ tests/` — clean